### PR TITLE
Typo fix. Yardes -> Yards

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $decimal_precision = 3;
 
 echo \Geodistance\kilometers($new_york, $los_angeles); // 3936
 echo \Geodistance\miles($new_york, $los_angeles, $decimal_precision); // 2445.564
-echo \Geodistance\yardes($new_york, $los_angeles); // 4304181
+echo \Geodistance\yards($new_york, $los_angeles); // 4304181
 
 ```
 

--- a/src/Location.php
+++ b/src/Location.php
@@ -82,7 +82,7 @@ function centimeters(location $x, location $y, $precision = 0)
     return round(meters($x, $y) * 100, $precision);
 }
 
-function yardes(location $x, location $y, $precision = 0)
+function yards(location $x, location $y, $precision = 0)
 {
     return round(meters($x, $y) * 1.09361, $precision);
 }


### PR DESCRIPTION
The plural of Yard is Yards, not Yardes.

(http://learnersdictionary.com/definition/yard)